### PR TITLE
expose x-cors-cache header as accessible to client

### DIFF
--- a/src/cors.coffee
+++ b/src/cors.coffee
@@ -12,6 +12,7 @@ module.exports = ->
       'access-control-allow-headers'     : headers
       'access-control-allow-credentials' : 'true'
       'access-control-allow-origin'      : req.headers.origin or "*"
+      'access-control-expose-headers'    : 'x-cors-cache'
       'x-frame-options'                  : ''
 
     res.setHeader(key, value) for key, value of corsHeaders


### PR DESCRIPTION
The client may want to react differently depending on if the request was cached or not. While we send this back as a header, by default the ajax client can't read random headers when using cors. So this exposes it.