### PR TITLE
proxy failure protections

### DIFF
--- a/src/proxy.coffee
+++ b/src/proxy.coffee
@@ -18,8 +18,9 @@ module.exports = (req, res) ->
   proxy = httpProxy.createProxyServer()
   proxy.on 'error', (err, req, res) ->
     console.error err
-    res.writeHead(500, {})
-    res.end 'Request failed.'
+    if !res.headersSent
+      res.writeHead(500, {})
+      res.end 'Request failed.'
 
   # ugly hack because http-proxy will only use the original request's path
   originalUrl = req.url


### PR DESCRIPTION
This will solve the problem of the server dying, but not of the underlying problem of bytes being sent after the request is closed.

My next thought is that we briefly remove the caching middleware and see if we still get the error. That way we'll know whether to focus on the caching layer or the proxy itself.