### PR TITLE
Start reporting stats for proxy requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "connect"            : "2.14.4",
     "raw-body"           : "1.1.4",
     "connect-restreamer" : "1.0.0",
-    "node-honeybadger"   : "0.5"
+    "node-honeybadger"   : "0.5",
+    "lynx"               : "0.2.0"
   },
   "scripts": {
     "start": "./node_modules/.bin/coffee src/server.coffee",

--- a/src/report_stats.coffee
+++ b/src/report_stats.coffee
@@ -1,0 +1,18 @@
+stats = require('./stats_reporter')
+
+module.exports = ->
+  (req, res, next) ->
+    start = new Date()
+
+    res.on 'finish', ->
+      reqTime = (new Date()) - start
+      cacheStatus = res.cacheStatus or 'miss'
+
+      stats.add("requests", "1|c")
+      stats.add("cache_#{cacheStatus}", "1|c")
+      stats.add(req.method, "1|c")
+      stats.add("response_time", "#{reqTime}|ms")
+
+      stats.send()
+
+    next()

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -8,6 +8,8 @@ cors          = require './cors'
 rawBody       = require './raw_body'
 proxy         = require './proxy'
 health        = require './health'
+statsReporter = require("./stats_reporter")
+stats         = require './report_stats'
 
 process.title = 'node (CORS proxy)'
 
@@ -16,6 +18,7 @@ cache = new Cache(CACHE_TIME, logging: false)
 
 app = connect()
   .use(requestLogger())
+  .use(stats())
   .use(health)
   .use(cors())
   .use(rawBody())
@@ -24,6 +27,7 @@ app = connect()
   .use(proxy)
 
 port = process.env.PORT || 9292
+statsReporter.setup()
 server = http.createServer(app)
 server.listen port
 

--- a/src/stats_reporter.coffee
+++ b/src/stats_reporter.coffee
@@ -1,0 +1,51 @@
+lynx = require('lynx')
+dns  = require('dns')
+os   = require("os")
+
+class StatsReporter
+  constructor: ->
+    @clear()
+
+  clear: ->
+    @_stats = {}
+
+  client: ->
+    @_client
+
+  stats: ->
+    @_stats
+
+  add: (key, value) ->
+    @_stats[key] = value
+
+  errorHandler: (err) ->
+    console.error('error reporting to statsd:', err)
+
+  send: ->
+    return unless @_client
+
+    fullStats = {}
+    for stat, value of @_stats
+      fullStats["#{@_prefix}.#{stat}"] = value
+
+    @_client.send fullStats
+    @clear()
+
+  setup: (callback) ->
+    hostname = os.hostname().split('.')[0]
+
+    statsd_host = process.env.STATSD_HOST || "localhost"
+    statsd_port = process.env.STATSD_PORT || 8125
+    @_prefix = process.env.STATSD_PREFIX || "cors.#{hostname}"
+
+    console.log("Reporting stats to #{statsd_host}:#{statsd_port} with prefix #{@_prefix}")
+
+    dns.lookup statsd_host, (err, ip) =>
+      unless err
+        @_client = new lynx(ip, statsd_port, {on_error: @errorHandler})
+
+      callback err if callback
+
+statsReporter = new StatsReporter()
+
+module.exports = statsReporter


### PR DESCRIPTION
Configured with environment variables:
`STATSD_HOST` defaults to `localhost`,
`STATSD_PORT` defaults to `8125`,
`STATSD_PREFIX`defaults to `cors.#{hostname}`

Writes counters for:
`requests`
`cache_hit`
`cache_miss`
`METHOD`

Write timers for:
`response_time`