### PR TITLE
node-http proxy 1.15.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const http          = require('http');
 const connect       = require('connect');
 const bodyParser    = require('body-parser');

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ process.title = 'node (cors proxy)';
 const CACHE_TIME = 10 * 1000; // 10s
 let cache = new Cache(CACHE_TIME, {logging: false});
 
-let app = connect()
+const app = connect()
   .use(requestLogger())
   .use(stats())
   .use(health)
@@ -28,7 +28,7 @@ let app = connect()
 
 const port = process.env.PORT || 9292;
 statsReporter.setup();
-let server = http.createServer(app);
+const server = http.createServer(app);
 
 server.listen(port, () => {
   log({ listening: true, port: port });

--- a/lib/cache-middleware.js
+++ b/lib/cache-middleware.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // cacheMiddleware caches requests using the request URL as the key
 //
 // If a request is already in progress for the specified key, it will hold all other

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Cache is a simple in-memory cache.
 //
 // It supports expiration (using setTimeout) and locking.

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function() {
   return function cors(req, res, next) {
     let headers;

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(data) {
   data.date = new Date().toISOString();
   console.log(JSON.stringify(data));

--- a/lib/parse-url.js
+++ b/lib/parse-url.js
@@ -30,6 +30,7 @@ module.exports = function parseUrl(requestUrl) {
   return {
     hostname: target.hostname,
     path: target.path,
-    target: target.format()
+    target: target.format(),
+    isHttps: (proto === 'https')
   };
 };

--- a/lib/parse-url.js
+++ b/lib/parse-url.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // parseUrl parses URLs out of paths
 //
 // Example:

--- a/lib/parse-url.js
+++ b/lib/parse-url.js
@@ -18,7 +18,8 @@ const url = require('url');
 module.exports = function parseUrl(requestUrl) {
   if (!requestUrl) { return { target: '', hostname: '' }; }
 
-  let [_, port] = (requestUrl.match(/^\/[^\/]+\:(\d+)/) || []);
+  let pair = (requestUrl.match(/^\/[^\/]+\:(\d+)/) || []);
+  let port = pair[1];
   port = parseInt(port, 10) || 80;
 
   const proto = port === 443 ? 'https' : 'http';

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -45,8 +45,15 @@ module.exports = function proxy(req, res) {
     headers: {
       host: proxyUrl.hostname
     }
-  }
-  );
+  });
+
+  proxy.on('econnreset', function(err, req, res, target) {
+    log({
+      proxyError: "connection reset",
+      detail: err,
+      target: target
+    });
+  });
 
   proxy.on('proxyReq', function(proxyReq, req) {
     proxyReq.path = proxyUrl.path;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -4,7 +4,7 @@ const httpProxy = require('http-proxy');
 const parseUrl = require('./parse-url');
 const log = require('./log');
 
-let corsHeaders = ['allow-origin', 'allow-headers', 'allow-credentials', 'allow-methods', 'max-age'];
+const corsHeaders = ['allow-origin', 'allow-headers', 'allow-credentials', 'allow-methods', 'max-age'];
 
 module.exports = function proxy(req, res) {
   const proxyUrl = parseUrl(req.url);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const httpProxy = require('http-proxy');
 const parseUrl = require('./parse-url');
 const log = require('./log');

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -35,6 +35,8 @@ module.exports = function proxy(req, res) {
     delete req.headers['x-mi-cbe'];
   }
 
+  req.headers['connection'] = 'keep-alive';
+
   let proxy = httpProxy.createProxyServer({ agent: agent });
   proxy.on('error', function(err, req, res) {
     log({

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -4,14 +4,18 @@ const httpProxy = require('http-proxy');
 const parseUrl = require('./parse-url');
 const log = require('./log');
 const http = require('http');
+const https = require('https');
 
-const agent = new http.Agent({
+const agentOptions = {
   maxSockets: 62000,
   keepAlive: true,
   maxFreeSockets: 1000,
   keepAliveMsecs: 100,
   timeout: 15000
-});
+};
+
+const httpAgent = new http.Agent(agentOptions);
+const httpsAgent = new https.Agent(agentOptions);
 
 const corsHeaders = ['allow-origin', 'allow-headers', 'allow-credentials', 'allow-methods', 'max-age'];
 
@@ -37,7 +41,9 @@ module.exports = function proxy(req, res) {
 
   req.headers['connection'] = 'keep-alive';
 
+  let agent = proxyUrl.isHttps ? httpsAgent : httpAgent;
   let proxy = httpProxy.createProxyServer({ agent: agent });
+
   proxy.on('error', function(err, req, res) {
     log({
       proxyError: "error event",

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -3,6 +3,15 @@
 const httpProxy = require('http-proxy');
 const parseUrl = require('./parse-url');
 const log = require('./log');
+const http = require('http');
+
+const agent = new http.Agent({
+  maxSockets: 62000,
+  keepAlive: true,
+  maxFreeSockets: 1000,
+  keepAliveMsecs: 100,
+  timeout: 15000
+});
 
 const corsHeaders = ['allow-origin', 'allow-headers', 'allow-credentials', 'allow-methods', 'max-age'];
 
@@ -26,7 +35,7 @@ module.exports = function proxy(req, res) {
     delete req.headers['x-mi-cbe'];
   }
 
-  let proxy = httpProxy.createProxyServer();
+  let proxy = httpProxy.createProxyServer({ agent: agent });
   proxy.on('error', function(err, req, res) {
     log({
       proxyError: "error event",

--- a/lib/report-stat.js
+++ b/lib/report-stat.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const stats = require('./stats-reporter');
 
 module.exports = function() {

--- a/lib/request-logger.js
+++ b/lib/request-logger.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const log = require('./log');
 
 module.exports = function() {

--- a/lib/response-body.js
+++ b/lib/response-body.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // responseBody sets a 'body' property on the response, useful for caching
 //
 // Returns a function that, when called, returns the body.  Returns null if

--- a/lib/stats-reporter.js
+++ b/lib/stats-reporter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const lynx = require('lynx');
 const dns = require('dns');
 const os = require('os');

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "connect"            : "2.30.2",
     "eventemitter3"      : "0.1.6",
-    "http-proxy"         : "1.13.2",
+    "http-proxy"         : "1.15.2",
     "lynx"               : "0.2.0",
     "body-parser"        : "1.15.0"
   },


### PR DESCRIPTION
Logs econnresets. We should figure out a way to test that we're still abandoning the cache in the event of an econnreset, but I'm fairly sure we are.