### PR TITLE
origin server returning HTTP status 0 breaks cors-proxy

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -83,6 +83,9 @@ module.exports = function proxy(req, res) {
 
   proxy.on('proxyRes', function(proxyRes) {
     if (proxyRes && proxyRes.headers) {
+      if(proxyRes.statusCode > 999 || proxyRes.statusCode <= 0) {
+        proxyRes.statusCode = 500;
+      }
       delete proxyRes.headers['x-frame-options'];
       corsHeaders.forEach((name) => {
         delete proxyRes.headers[`access-control-${name}`];


### PR DESCRIPTION
We've seen some origin servers sending http status zero. Node doesn't like this, and throws.

Unfortunately there's no test for this because the way we test means that if I bypass node's http status checks for the fake server, the test becomes meaningless. But I've tested manually with a fake server I've set up and this patch addresses the problem.