### PR TITLE
No cookies

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -37,6 +37,7 @@ module.exports = function proxy(req, res) {
     delete req.headers['x-forwarded-proto'];
     delete req.headers['x-forwarded-for'];
     delete req.headers['x-mi-cbe'];
+    delete req.headers['cookie'];
   }
 
   req.headers['connection'] = 'keep-alive';


### PR DESCRIPTION
This ensures that cookies passed by the browser to cors-proxy do not get forwarded onward to the origin. Since we don't have any capacity to store cookies anyway, we don't want junk cookies getting sent over.

I neglected to add a test because it's a simple change and `lib/proxy.js` unfortunately doesn't have existing tests and cors-proxy is being phased out.

I verified that nobody is currently using `withCredentials` to access cors-proxy so this change should not negatively impact any existing users.