### PR TITLE
Drop expect header from outgoing proxy requests

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -38,6 +38,7 @@ module.exports = function proxy(req, res) {
     delete req.headers['x-forwarded-for'];
     delete req.headers['x-mi-cbe'];
     delete req.headers['cookie'];
+    delete req.headers['expect'];
   }
 
   req.headers['connection'] = 'keep-alive';


### PR DESCRIPTION
They're not handled properly and result in invalid requests on the downstream side