### PR TITLE
Reject requests with headers that contain invalid characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
 'use strict';
 
-const http          = require('http');
-const connect       = require('connect');
-const bodyParser    = require('body-parser');
-const Cache         = require('./lib/cache');
-const requestLogger = require('./lib/request-logger');
-const cors          = require('./lib/cors');
-const proxy         = require('./lib/proxy');
-const health        = require('./lib/health');
-const statsReporter = require('./lib/stats-reporter');
-const stats         = require('./lib/report-stat');
-const log           = require('./lib/log');
+const http           = require('http');
+const connect        = require('connect');
+const bodyParser     = require('body-parser');
+const Cache          = require('./lib/cache');
+const headerValidity = require('./lib/header-validity');
+const requestLogger  = require('./lib/request-logger');
+const cors           = require('./lib/cors');
+const proxy          = require('./lib/proxy');
+const health         = require('./lib/health');
+const statsReporter  = require('./lib/stats-reporter');
+const stats          = require('./lib/report-stat');
+const log            = require('./lib/log');
 
 process.title = 'node (cors proxy)';
 
@@ -18,6 +19,7 @@ const CACHE_TIME = 10 * 1000; // 10s
 let cache = new Cache(CACHE_TIME, {logging: false});
 
 const app = connect()
+  .use(headerValidity.checkHeaderValidity)
   .use(requestLogger())
   .use(stats())
   .use(health)

--- a/lib/header-validity.js
+++ b/lib/header-validity.js
@@ -1,0 +1,19 @@
+const invalidCharacters = /[^\t\x20-\x7e\x80-\xff]/g;
+
+function hasInvalidCharacters(value) {
+  return !!value.match(invalidCharacters);
+}
+
+function checkHeaderValidity(req, res, next) {
+  if (Object.entries(req.headers).some(([key,value]) => hasInvalidCharacters(value))) {
+    res.writeHead(500, {});
+    res.end('The header content contains invalid characters');
+  } else {
+    next();
+  }
+}
+
+module.exports = {
+  hasInvalidCharacters: hasInvalidCharacters,
+  checkHeaderValidity: checkHeaderValidity
+}

--- a/test/header-validity-test.js
+++ b/test/header-validity-test.js
@@ -1,0 +1,14 @@
+const headerValidity = require('../lib/header-validity');
+const should         = require('should');
+
+describe('headerValidity', function() {
+  describe('hasInvalidCharacters', function() {
+    it('should return true when invalid characters are present', function() {
+      headerValidity.hasInvalidCharacters('ƒoo').should.be.exactly(true);
+    });
+
+    it('should return false when no invalid characters are present', function () {
+      headerValidity.hasInvalidCharacters('foo').should.be.exactly(false);
+    });
+  });
+});


### PR DESCRIPTION
Reject requests with invalid headers.  The response will be a 500 with a body of `The header content contains invalid characters`